### PR TITLE
Fix iOS detection in manifest selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
         }
 
         var userAgent = navigator.userAgent.toLowerCase();
-        if (userAgent.indexOf("iphone") > 0 || userAgent.indexOf("ipad") > 0) {
-            setManifest('manifest_ios.json')
+        if (/iphone|ipad|ipod/.test(userAgent)) {
+            setManifest('manifest_ios.json');
         } else {
-            setManifest('manifest.json')
+            setManifest('manifest.json');
         }
         
         if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- improve iOS device check when deciding which manifest to load

## Testing
- `npm test` *(fails: could not find package.json)*